### PR TITLE
Update use of attempt_import in `incidence_analysis`

### DIFF
--- a/pyomo/common/dependencies.py
+++ b/pyomo/common/dependencies.py
@@ -661,19 +661,19 @@ def _finalize_numpy(np, available):
         numeric_types.RegisterBooleanType(t)
 
 
-yaml, yaml_available = attempt_import(
-    'yaml', callback=_finalize_yaml)
-pympler, pympler_available = attempt_import(
-    'pympler', callback=_finalize_pympler)
-numpy, numpy_available = attempt_import(
-    'numpy', callback=_finalize_numpy)
-scipy, scipy_available = attempt_import(
-    'scipy', callback=_finalize_scipy,
-    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate'])
-networkx, networkx_available = attempt_import('networkx')
-pandas, pandas_available = attempt_import('pandas')
 dill, dill_available = attempt_import('dill')
+networkx, networkx_available = attempt_import('networkx')
+numpy, numpy_available = attempt_import('numpy', callback=_finalize_numpy)
+pandas, pandas_available = attempt_import('pandas')
+plotly, plotly_available = attempt_import('plotly')
+pympler, pympler_available = attempt_import('pympler', callback=_finalize_pympler)
 pyutilib, pyutilib_available = attempt_import('pyutilib')
+scipy, scipy_available = attempt_import(
+    'scipy',
+    callback=_finalize_scipy,
+    deferred_submodules=['stats', 'sparse', 'spatial', 'integrate']
+)
+yaml, yaml_available = attempt_import('yaml', callback=_finalize_yaml)
 
 # Note that matplotlib.pyplot can generate a runtime error on OSX when
 # not installed as a Framework (as is the case in the CI systems)

--- a/pyomo/contrib/incidence_analysis/interface.py
+++ b/pyomo/contrib/incidence_analysis/interface.py
@@ -28,6 +28,7 @@ from pyomo.common.dependencies import (
     attempt_import,
     scipy_available,
     scipy as sp,
+    plotly,
 )
 from pyomo.common.dependencies import networkx as nx
 from pyomo.common.deprecation import deprecated
@@ -54,9 +55,6 @@ if asl_available and scipy_available:
     # Not sure if asl_available is necessary for this import...
     from pyomo.contrib.pynumero.interfaces.pyomo_nlp import PyomoNLP
 
-plotly, plotly_available = attempt_import("plotly")
-if plotly_available:
-    go = plotly.graph_objects
 
 
 def _check_unindexed(complist):
@@ -881,7 +879,7 @@ class IncidenceGraphInterface(object):
             edge_y.append(y0)
             edge_y.append(y1)
             edge_y.append(None)
-        edge_trace = go.Scatter(
+        edge_trace = plotly.graph_objects.Scatter(
             x=edge_x,
             y=edge_y,
             line=dict(width=0.5, color='#888'),
@@ -919,7 +917,7 @@ class IncidenceGraphInterface(object):
                     f'value: {str(v.value)}<br>domain: {str(v.domain)}<br>'
                     f'fixed: {str(v.is_fixed())}'
                 )
-        node_trace = go.Scatter(
+        node_trace = plotly.graph_objects.Scatter(
             x=node_x,
             y=node_y,
             mode='markers',
@@ -927,7 +925,7 @@ class IncidenceGraphInterface(object):
             text=node_text,
             marker=dict(color=node_color, size=10),
         )
-        fig = go.Figure(data=[edge_trace, node_trace])
+        fig = plotly.graph_objects.Figure(data=[edge_trace, node_trace])
         if title is not None:
             fig.update_layout(title=dict(text=title))
         if show:

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -14,10 +14,10 @@ from pyomo.common.dependencies import (
     networkx_available,
     plotly_available,
     scipy_available,
-    attempt_import,
 )
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.contrib.incidence_analysis.interface import (
+    asl_available,
     IncidenceGraphInterface,
     get_structural_incidence_matrix,
     get_numeric_incidence_matrix,
@@ -42,14 +42,13 @@ if scipy_available:
 if networkx_available:
     import networkx as nx
     from networkx.algorithms.bipartite.matrix import from_biadjacency_matrix
-from pyomo.contrib.pynumero.asl import AmplInterface
 
 import pyomo.common.unittest as unittest
 
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestGasExpansionNumericIncidenceMatrix(unittest.TestCase):
     """
     This class tests the get_numeric_incidence_matrix function on
@@ -434,7 +433,7 @@ class TestGasExpansionStructuralIncidenceMatrix(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestGasExpansionModelInterfaceClassNumeric(unittest.TestCase):
     # In these tests, we pass the interface a PyomoNLP and cache
     # its Jacobian.
@@ -1345,7 +1344,7 @@ class TestExtraVars(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestExceptions(unittest.TestCase):
 
     def test_nlp_fixed_error(self):
@@ -1379,7 +1378,7 @@ class TestExceptions(unittest.TestCase):
 
 @unittest.skipUnless(networkx_available, "networkx is not available.")
 @unittest.skipUnless(scipy_available, "scipy is not available.")
-@unittest.skipUnless(AmplInterface.available(), "pynumero_ASL is not available")
+@unittest.skipUnless(asl_available, "pynumero PyomoNLP is not available")
 class TestIncludeInequality(unittest.TestCase):
     def make_model_with_inequalities(self):
         m = make_degenerate_solid_phase_model()

--- a/pyomo/contrib/incidence_analysis/tests/test_interface.py
+++ b/pyomo/contrib/incidence_analysis/tests/test_interface.py
@@ -12,10 +12,10 @@
 import pyomo.environ as pyo
 from pyomo.common.dependencies import (
     networkx_available,
+    plotly_available,
     scipy_available,
     attempt_import,
 )
-plotly, plotly_available = attempt_import("plotly")
 from pyomo.common.collections import ComponentSet, ComponentMap
 from pyomo.contrib.incidence_analysis.interface import (
     IncidenceGraphInterface,


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This cleans up how we use attempt_import in incidence_analysis:
- move plotly import to `pyomo.common.dependencies`
- leverage the deferred boolean logic handlers (part of the `DeferredImportIndicator` to not force the import of `scipy` upon import of `interface.py`


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
