### PR TITLE
Fix shift value error for measurement parameter

### DIFF
--- a/pyomo/contrib/mpc/examples/cstr/run_mhe.py
+++ b/pyomo/contrib/mpc/examples/cstr/run_mhe.py
@@ -185,7 +185,7 @@ def run_cstr_mhe(
         #
         # Solve plant model to simulate
         #
-        res = solver.solve(m_plant, tee=True)
+        res = solver.solve(m_plant, tee=False)
         pyo.assert_optimal_termination(res)
 
         #

--- a/pyomo/contrib/mpc/examples/cstr/run_mhe.py
+++ b/pyomo/contrib/mpc/examples/cstr/run_mhe.py
@@ -68,19 +68,14 @@ def run_cstr_mhe(
     ]
     m_estimator.sample_points = ContinuousSet(initialize=sample_points)
 
-    #
-    # Construct components for measurements and measurement errors
-    #
-    m_estimator.estimation_block = pyo.Block()
-    esti_blo = m_estimator.estimation_block
-
     measured_variables = [pyo.Reference(m_estimator.conc[:, "A"])]
 
     meas_set, measurements = get_parameters_from_variables(
-        measured_variables, m_estimator.sample_points
+        measured_variables, m_estimator.sample_points, ctype=pyo.Var
     )
     m_estimator.measurement_set = meas_set
     m_estimator.measurements = measurements
+    m_estimator.measurements.fix()
 
     #
     # Construct disturbed model constraints
@@ -190,7 +185,7 @@ def run_cstr_mhe(
         #
         # Solve plant model to simulate
         #
-        res = solver.solve(m_plant, tee=False)
+        res = solver.solve(m_plant, tee=True)
         pyo.assert_optimal_termination(res)
 
         #

--- a/pyomo/contrib/mpc/modeling/cost_expressions.py
+++ b/pyomo/contrib/mpc/modeling/cost_expressions.py
@@ -59,7 +59,7 @@ def _get_indexed_parameters(n, time, ctype=Param, initialize=None):
     elif ctype is Var:
         # Create a fixed variables
         comp = ctype(range_set, time, initialize=initialize)
-        comp.fix()
+        # comp.fix() # KH: cannot fix a variable before it is constructed.
     return range_set, comp
 
 


### PR DESCRIPTION
## Summary/Motivation:
I figure out the offset estimation on state `conc[ : , 'B']`. The inaccurate estimation is because `DynamicModelInterface` cannot handle `measurement`, which is constructed as a parameter. In particular, the method `shift_values_by_time` does not work on these `measurement` components on line 237 in `run_mhe.py`.

Therefore, I construct `measurement` as a variable and the offset vanishes. Now we have another problem.

`measurement` has to be a **fixed** variable, but we cannot fix it before it is constructed. I comment out the fix function in `cost_expression.py` and fix the variable in `run_mhe.py`.

Another proposed way is to separate the function `shift_values_by_time`  from `DynamicModelInterface` as an individual function so it can handle any type of component (Var or Param), but we need to change the function that is already in pyomo main (is it difficult to do so?).

Please take a look and let me know what you think when you have a chance. We can schedule a meeting if that's easier to discuss. Thanks! 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
